### PR TITLE
docs: fix target file wildcard argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ yarn
 ## Run codemod
 
 ```shell
-npx jscodeshift -t ./examples/simple-rename.ts --extensions=ts --parser=ts './**/*.ts' --print --dry
+npx jscodeshift -t ./examples/simple-rename.ts --extensions=ts --parser=ts ./**/*.ts --print --dry
 ```
 
 > _Omit `--dry` to write the transformed source back to disk._


### PR DESCRIPTION
Current readme is incorrect. I actually got this instead when I tried it.

#### Command
I'm using an alias for convenience purposes. Pretend `yarn mod` is equivalent to `npx jscodeshift`.
```shell
yarn mod -t ./examples/simple-rename.ts --extensions=ts --parser=ts 'sandbox/**/*.ts' --print --dry
```

#### Output
```shell
csantarin ~/javascript-apps/jscodeshift-tsx-example (master) $ yarn mod -t ./examples/simple-rename.ts --extensions=ts --parser=ts 'sandbox/**/*.ts' --print --dry
# Don't mind the "yarn mod". I'm using the local project's jscodeshift instance.

yarn run v1.22.17
$ jscodeshift -t ./examples/simple-rename.ts --extensions=ts --parser=ts 'sandbox/**/*.ts' --print --dry
Skipping path sandbox/**/*.ts which does not exist. 
No files selected, nothing to do. 
All done. 
Results: 
0 errors
0 unmodified
0 skipped
0 ok
Time elapsed: 0.002seconds 
✨  Done in 0.40s.
```

Target file: `sandbox/bar/bar.ts`

File structure:
<img width="346" alt="image" src="https://user-images.githubusercontent.com/67677362/173030233-9751c0dd-0d53-49c3-83fd-fb7a2b1185b3.png">

Removing the single quotes allows the wildcard to work.